### PR TITLE
Added function to compute convolution.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ FIND_PACKAGE(IBAMR REQUIRED)
 
 SET(CXX_SRC
     CohesionStressRHS.cpp
+    utility_functions.cpp
     )
 ADD_EXECUTABLE(main2d main.cpp)
 TARGET_SOURCES(main2d PRIVATE ${CXX_SRC})

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ include $(IBAMR_BUILD_DIR)/config/make.inc
 ## main driver is in main.cpp
 ##
 ## PDIM = 2 implies two spatial dimensions
-OBJS = CohesionRHS.o
+OBJS = CohesionRHS.o utility_functions.o
 #main.o
 PDIM = 2
 

--- a/utility_functions.cpp
+++ b/utility_functions.cpp
@@ -1,0 +1,42 @@
+#include <ibamr/app_namespaces.h>
+
+#include <ibtk/ibtk_utilities.h>
+
+#include <Box.h>
+
+// Local includes
+#include "utility_functions.h"
+
+namespace IBAMR
+{
+double
+convolution(double alpha,
+            const CellData<NDIM, double>& a_data,
+            double beta,
+            const CellData<NDIM, double>& b_data,
+            std::function<double(double)> phi,
+            unsigned int phi_width,
+            const CellIndex<NDIM>& idx,
+            const double* const dx)
+{
+    // Box over which integration is performed
+    Box<NDIM> int_box(idx, idx);
+    int_box.grow(phi_width);
+#ifndef NDEBUG
+    // Error checking. Need ghost data for patch data.
+    TBOX_ASSERT(a_data.getGhostBox() * int_box == int_box);
+    TBOX_ASSERT(b_data.getGhostBox() * int_box == int_box);
+#endif
+    // Now compute convolution
+    double convolve = 0.0;
+    for (CellIterator<NDIM> ci(int_box); ci; ci++)
+    {
+        const CellIndex<NDIM>& n_idx = ci();
+        double phi_weight = 1.0;
+        ;
+        for (int d = 0; d < NDIM; ++d) phi_weight *= phi(static_cast<double>(n_idx(d) - idx(d))) * dx[d];
+        convolve += (alpha * a_data(n_idx) + beta * b_data(n_idx)) * phi_weight;
+    }
+    return convolve;
+}
+} // namespace IBAMR

--- a/utility_functions.h
+++ b/utility_functions.h
@@ -1,0 +1,32 @@
+/////////////////////////////// INCLUDE GUARD ////////////////////////////////
+
+#ifndef included_utility_functions
+#define included_utility_functions
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+#include <ibamr/config.h>
+
+#include <CellData.h>
+#include <CellIndex.h>
+
+#include <functional>
+namespace IBAMR
+{
+/*!
+ * Computes the convolution of (alpha*a + beta*b) and the function phi at a given patch index, assuming phi has finite
+ * support.
+ *
+ * Both patch data MUST have enough ghost cells for the width of the phi function. This assumes the phi function is
+ * centered at idx and scaled by the grid spacing.
+ */
+double convolution(double alpha,
+                   const SAMRAI::pdat::CellData<NDIM, double>& a_data,
+                   double beta,
+                   const SAMRAI::pdat::CellData<NDIM, double>& b_data,
+                   std::function<double(double)> phi,
+                   unsigned int phi_width,
+                   const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                   const double* const dx);
+} // namespace IBAMR
+
+#endif // included_utility_functions


### PR DESCRIPTION
This computes a convolution of `(alpha * a + beta * b)`  and a function `phi(r)` at a specified cell index. Note that phi is assumed to be of the form `phi(r) = phi(x)*phi(y)` (like IB delta functions).

@jmcragun, take a look and feel free to merge if this makes sense to you.