### PR TITLE
Prevent upstream growth

### DIFF
--- a/BoundaryMeshMapping.cpp
+++ b/BoundaryMeshMapping.cpp
@@ -61,7 +61,7 @@ BoundaryMeshMapping::commonConstructor(Pointer<Database> input_db)
             // If this element has nodes on the bottom half of the cylinder, delete it.
             for (unsigned int n = 0; n < e->n_nodes(); ++n)
             {
-                if (e->node_ref(n)(1) < 0.0)
+                if (e->node_ref(n)(1) < 0.5)
                 {
                     d_bdry_meshes[part]->delete_elem(e);
                     break;
@@ -73,7 +73,7 @@ BoundaryMeshMapping::commonConstructor(Pointer<Database> input_db)
         {
             Node* n = *it;
             // If the node is on the bottom half of the cylinder, delete it.
-            if ((*n)(1) < 0.0) d_bdry_meshes[part]->delete_node(n);
+            if ((*n)(1) < 0.5) d_bdry_meshes[part]->delete_node(n);
         }
         d_bdry_meshes[part]->prepare_for_use();
         d_bdry_meshes[part]->print_info();

--- a/utility_functions.cpp
+++ b/utility_functions.cpp
@@ -42,4 +42,25 @@ convolution(double alpha,
     }
     return convolve;
 }
+
+double
+convolution_mask(double alpha,
+                 CellData<NDIM, double>* a_data,
+                 double beta,
+                 CellData<NDIM, double>* b_data,
+                 std::function<double(double)> phi,
+                 unsigned int phi_width,
+                 const CellIndex<NDIM>& idx,
+                 const double* const dx,
+                 const VectorNd& x,
+                 const std::array<VectorNd, 2>& xbds)
+{
+    double convolve = convolution(alpha, a_data, beta, b_data, phi, phi_width, idx, dx);
+    // Now mask the convolution with a heaviside function.
+    // Determine if we are outside the box determined by xbds.
+    if ((x(0) < xbds[0](0) || x(0) > xbds[1](0)) || (x(1) < xbds[0](1) || x(1) > xbds[1](1)))
+        return 0.0;
+    else
+        return convolve;
+}
 } // namespace IBAMR

--- a/utility_functions.h
+++ b/utility_functions.h
@@ -31,6 +31,17 @@ double convolution(double alpha,
                    const SAMRAI::pdat::CellIndex<NDIM>& idx,
                    const double* const dx);
 
+double convolution_mask(double alpha,
+                        SAMRAI::pdat::CellData<NDIM, double>* a_data,
+                        double beta,
+                        SAMRAI::pdat::CellData<NDIM, double>* b_data,
+                        std::function<double(double)> phi,
+                        unsigned int phi_width,
+                        const SAMRAI::pdat::CellIndex<NDIM>& idx,
+                        const double* const dx,
+                        const VectorNd& x,
+                        const std::array<VectorNd, 2>& xbds);
+
 enum Kernel
 {
     BSPLINE_2,


### PR DESCRIPTION
This attempts to prevent upstream growth of the clot by masking the convolution and shrinking the initial size of the reaction zone.

The mask of the convolution prevents activated platelets from activating other platelets except in a box around the cylinder.

The initial wall sites are now chosen if their physical location is above the `y = 0.5` line.