### PR TITLE
Add option to oscillate structure

### DIFF
--- a/input2d
+++ b/input2d
@@ -32,15 +32,15 @@ P_INLET = 12.5
 
 // Model parameters
 UNACTIVATED_DIFFUSION_COEF = 1.0e-7
-ACTIVATED_DIFFUSION_COEF = 1.0e-7
+ACTIVATED_DIFFUSION_COEF = 0.0
 C4 = 4.0
-A0 = 0.6
-A0W = 0.6
-BETA_0 = 0.05
-BETA_1 = 10.0
+A0 = 1.0
+A0W = 1.0
+BETA_0 = 0.1
+BETA_1 = 0.1 
 R_0 = 1.0
-KUA = 0.6 / 12.0
-KUW = 0.6 / 12.0
+KUA = 2.0
+KUW = 2.0
 WMAX = 1.0
 PL_U_IN = 1.0
 
@@ -57,7 +57,7 @@ CONVECTIVE_FORM    = "ADVECTIVE"          // how to compute the convective terms
 NORMALIZE_PRESSURE = FALSE                 // whether to explicitly force the pressure to have mean zero
 CFL_MAX            = 0.3                  // maximum CFL number
 U_MAX              = RE * MU / (RHO * RADIUS)
-DT_MAX = 0.1/4.0*DX * CFL_MAX / U_MAX
+DT_MAX = 0.25*DX * CFL_MAX / U_MAX
 DT_MIN = 0.1 * DT_MAX
 END_TIME = 50.0
 VORTICITY_TAGGING  = TRUE                // whether to tag cells for refinement based on vorticity thresholds
@@ -66,7 +66,7 @@ REGRID_CFL_INTERVAL    = 0.75
 ERROR_ON_DT_CHANGE = TRUE
 SPLIT_FORCES = FALSE
 USE_JUMP_CONDITIONS = FALSE
-USE_CONSISTENT_MASS_MATRIX = TRUE
+USE_CONSISTENT_MASS_MATRIX = FALSE
 IB_USE_NODAL_QUADRATURE = TRUE
 IB_POINT_DENSITY = 1.0
 IB_DELTA_FUNCTION = "BSPLINE_6"
@@ -89,13 +89,17 @@ SECOND_ORDER_PRESSURE_UPDATE = TRUE
 P = "1.0"
 
 // Structural parameters
-KAPPA = 9.33837890625 * DX / DT_MAX / DT_MAX
-ETA = 0.873046875 * DX / DT_MAX
-BETA_S = 0.5*142.1875000*100.0
+KAPPA = 29.52550488335 * DX / DT_MAX / DT_MAX
+ETA = 8.8476185 * DX / DT_MAX
+BETA_S = 0.5*296.875000*1000.0
 ERROR_ON_MOVE = TRUE
 MFAC = 1.0
 ELEM_TYPE = "TRI3"
 ELEM_ORDER = "SECOND"
+
+Amplitude = 1.0
+Frequency = 4.0
+T_START = 25.0
 
 UnactivatedPlatelets
 {

--- a/tests/fsi/input2d
+++ b/tests/fsi/input2d
@@ -31,7 +31,7 @@ CONVECTIVE_FORM    = "ADVECTIVE"          // how to compute the convective terms
 NORMALIZE_PRESSURE = FALSE                 // whether to explicitly force the pressure to have mean zero
 CFL_MAX            = 0.3                  // maximum CFL number
 U_MAX              = RE * MU / (RHO * RADIUS)
-DT_MAX = 0.1/4.0*DX * CFL_MAX / U_MAX
+DT_MAX = 0.25*DX * CFL_MAX / U_MAX
 DT_MIN = 0.1 * DT_MAX
 END_TIME = 50.0
 VORTICITY_TAGGING  = TRUE                // whether to tag cells for refinement based on vorticity thresholds
@@ -40,7 +40,7 @@ REGRID_CFL_INTERVAL    = 0.75
 ERROR_ON_DT_CHANGE = TRUE
 SPLIT_FORCES = FALSE
 USE_JUMP_CONDITIONS = FALSE
-USE_CONSISTENT_MASS_MATRIX = TRUE
+USE_CONSISTENT_MASS_MATRIX = FALSE
 IB_USE_NODAL_QUADRATURE = TRUE
 IB_POINT_DENSITY = 1.0
 IB_DELTA_FUNCTION = "BSPLINE_6"
@@ -52,13 +52,17 @@ OUTPUT_DIV_U       = TRUE
 ENABLE_LOGGING     = TRUE
 
 // Structural parameters
-KAPPA = 9.33837890625 * DX / DT_MAX / DT_MAX
-ETA = 0.873046875 * DX / DT_MAX
-BETA_S = 0.5*142.1875000*100.0
+KAPPA = 29.52550488335 * DX / DT_MAX / DT_MAX
+ETA = 8.8476185 * DX / DT_MAX
+BETA_S = 0.5*296.875000*1000.0
 ERROR_ON_MOVE = TRUE
 MFAC = 1.5
 ELEM_TYPE = "TRI3"
 ELEM_ORDER = "SECOND"
+
+Amplitude = 1.0
+Frequency = 4.0
+TIME_TO_START = 4.0
 
 BoundaryMesh {
   elem_order = ELEM_ORDER

--- a/tests/fsi/main.cpp
+++ b/tests/fsi/main.cpp
@@ -61,6 +61,28 @@ static double eta = 0.0;
 static double beta_s = 1.0e3;
 static double dx = -1.0;
 static bool ERROR_ON_MOVE = false;
+
+double A = 1.0;
+double f = 1.0;
+double t_start = 0.0;
+libMesh::Point
+center(const double t)
+{
+    // Return the displacement of the center as a function of time.
+    libMesh::Point d;
+    if (t >= t_start) d(0) = A * std::sin(2.0 * M_PI * (t - t_start) / f);
+    return d;
+}
+
+VectorNd
+center_vel(const double t)
+{
+    // Return the derivative of the displacement
+    VectorNd d(VectorNd::Zero());
+    if (t >= t_start) d[0] = 2.0 * M_PI * A / f * std::cos(2.0 * M_PI * (t - t_start) / f);
+    return d;
+}
+
 void
 tether_force_function(VectorValue<double>& F,
                       const TensorValue<double>& /*FF*/,
@@ -69,17 +91,18 @@ tether_force_function(VectorValue<double>& F,
                       Elem* const /*elem*/,
                       const vector<const vector<double>*>& var_data,
                       const vector<const vector<VectorValue<double>>*>& /*grad_var_data*/,
-                      double /*time*/,
+                      double time,
                       void* /*ctx*/)
 {
     // Tether to initial location using damped springs
     // x is current location
     // X is reference location
     // U is velocity
+    const libMesh::Point disp = center(time) + X;
     const std::vector<double>& U = *var_data[0];
-    for (unsigned int d = 0; d < NDIM; ++d) F(d) = kappa * (X(d) - x(d)) - eta * U[d];
+    for (unsigned int d = 0; d < NDIM; ++d) F(d) = kappa * (disp(d) - x(d)) - eta * (U[d] - center_vel(time)[d]);
     // Check to see how much structure has moved. If more than a quarter of a grid cell, quit.
-    std::vector<double> d = { std::abs(x(0) - X(0)), std::abs(x(1) - X(1)) };
+    std::vector<double> d = { std::abs(x(0) - disp(0)), std::abs(x(1) - disp(1)) };
     if (ERROR_ON_MOVE && ((d[0] > 0.25 * dx) || (d[1] > 0.25 * dx))) TBOX_ERROR("Structure has moved too much.\n");
 }
 
@@ -96,7 +119,7 @@ tether_penalty_stress_fcn(TensorValue<double>& PP,
 {
     const TensorValue<double> FF_inv_trans = tensor_inverse_transpose(FF, NDIM);
     double J = FF.det();
-    PP = beta_s * J * log(J) * FF_inv_trans;
+    PP = beta_s * log(J) * FF_inv_trans;
     return;
 }
 
@@ -298,6 +321,10 @@ main(int argc, char* argv[])
             }
             ins_integrator->registerPhysicalBoundaryConditions(u_bc_coefs);
         }
+
+        A = input_db->getDouble("Amplitude");
+        f = input_db->getDouble("Frequency");
+        t_start = input_db->getDouble("T_START");
 
         // Set up visualization plot file writers.
         Pointer<VisItDataWriter<NDIM>> visit_data_writer = app_initializer->getVisItDataWriter();


### PR DESCRIPTION
This adds the option to prescribe an oscillatory motion for the structure using penalty springs.

There was also an incorrect option specified that used both nodal quadrature without mass lumping. This combination of options required a smaller time step for stability. This fixes that option, retunes the penalty springs, and changes some default options.