### PR TITLE
Force clot to break up downstream of cylinder.

### DIFF
--- a/BondSource.cpp
+++ b/BondSource.cpp
@@ -158,11 +158,17 @@ BondSource::setDataOnPatch(const int data_idx,
         patch->getPatchData(d_sig_var, d_adv_diff_hier_integrator->getScratchContext());
     Pointer<CellData<NDIM, double>> w_data = patch->getPatchData(d_w_idx);
     const Box<NDIM>& patch_box = patch->getBox();
+    Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
+    const double* const dx = pgeom->getDx();
+    const double* const xlow = pgeom->getXLower();
+    const hier::Index<NDIM>& idx_low = patch_box.lower();
     // begin cell loop
     for (CellIterator<NDIM> ci(patch_box); ci; ci++)
     {
         // grab the index
         const CellIndex<NDIM>& idx = ci();
+        VectorNd x;
+        for (int d = 0; d < NDIM; ++d) x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + 0.5);
         // grab the var values w/ the index
         double phi_u = (*phi_u_data)(idx);
         double phi_a = (*phi_a_data)(idx);
@@ -174,6 +180,7 @@ BondSource::setDataOnPatch(const int data_idx,
         const double trace = (*sig_data)(idx, 0) + (*sig_data)(idx, 1);
         const double y_brackets = trace / (z + 1.0e-8);
         double beta = d_beta_fcn(y_brackets);
+        if (x[0] > 2.25) beta = 300.0;
 #endif
 #if (NDIM == 3)
         const double trace = (*sig_data)(idx, 0) + (*sig_data)(idx, 1) + (*sig_data)(idx, 2);

--- a/BondSource.cpp
+++ b/BondSource.cpp
@@ -38,6 +38,8 @@ BondSource::BondSource(SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM>> phi_u
     // init db vars
     d_a0 = input_db->getDouble("a0");
     d_a0w = input_db->getDouble("a0w");
+    d_beta_limit = input_db->getDoubleWithDefault("beta_limit", 300.0);
+    d_clot_break_x = input_db->getDoubleWithDefault("clot_break_x", 2.25);
 } // BondSource
 
 bool
@@ -180,7 +182,7 @@ BondSource::setDataOnPatch(const int data_idx,
         const double trace = (*sig_data)(idx, 0) + (*sig_data)(idx, 1);
         const double y_brackets = trace / (z + 1.0e-8);
         double beta = d_beta_fcn(y_brackets);
-        if (x[0] > 2.25) beta = 300.0;
+        if (x[0] > d_clot_break_x) beta = d_beta_limit;
 #endif
 #if (NDIM == 3)
         const double trace = (*sig_data)(idx, 0) + (*sig_data)(idx, 1) + (*sig_data)(idx, 2);

--- a/BondSource.h
+++ b/BondSource.h
@@ -97,6 +97,10 @@ private:
     double d_a0 = std::numeric_limits<double>::quiet_NaN();
     double d_a0w = std::numeric_limits<double>::quiet_NaN();
 
+    // When X is greater than d_clot_break_x, set beta equal to d_beta_limit;
+    double d_clot_break_x = std::numeric_limits<double>::quiet_NaN();
+    double d_beta_limit = std::numeric_limits<double>::quiet_NaN();
+
     // wall index
     int d_w_idx = IBTK::invalid_index;
 

--- a/CohesionStressRHS.cpp
+++ b/CohesionStressRHS.cpp
@@ -43,6 +43,8 @@ CohesionStressRHS::CohesionStressRHS(Pointer<Variable<NDIM>> phi_u_var,
     // a0 Constants
     d_a0 = input_db->getDouble("a0");
     d_a0w = input_db->getDouble("a0w");
+    d_beta_limit = input_db->getDoubleWithDefault("beta_limit", 300.0);
+    d_clot_break_x = input_db->getDoubleWithDefault("clot_break_x", 2.25);
     return;
 } // Constructor
 
@@ -181,7 +183,7 @@ CohesionStressRHS::setDataOnPatch(const int data_idx,
         const double trace = (*in_data)(idx, 0) + (*in_data)(idx, 1);
         const double y_brackets = trace / (z + 1.0e-8);
         double beta = d_beta_fcn(y_brackets);
-        if (x[0] > 2.25) beta = 300.0;
+        if (x[0] > d_clot_break_x) beta = d_beta_limit;
 
         (*ret_data)(idx, 0) = d_c4 * alpha - beta * (*in_data)(idx, 0);
         (*ret_data)(idx, 1) = d_c4 * alpha - beta * (*in_data)(idx, 1);

--- a/CohesionStressRHS.h
+++ b/CohesionStressRHS.h
@@ -132,6 +132,11 @@ private:
     double d_a0 = std::numeric_limits<double>::quiet_NaN();
     double d_a0w = std::numeric_limits<double>::quiet_NaN();
     SAMRAI::tbox::Pointer<SAMRAI::hier::Variable<NDIM>> d_phi_u_var, d_phi_a_var, d_z_var;
+
+    // When X is greater than d_clot_break_x, set beta equal to d_beta_limit;
+    double d_clot_break_x = std::numeric_limits<double>::quiet_NaN();
+    double d_beta_limit = std::numeric_limits<double>::quiet_NaN();
+
     // Beta function pointer
     std::function<double(double)> d_beta_fcn;
 

--- a/input2d
+++ b/input2d
@@ -43,6 +43,8 @@ KUA = 2.0
 KUW = 2.0
 WMAX = 1.0
 PL_U_IN = 1.0
+CLOT_BREAK_X = 2.25
+BETA_LIMIT = 300.0
 
 // solver parameters
 NORMALIZE_VELOCITY = FALSE
@@ -119,6 +121,8 @@ BondVariable {
   a0 = A0
   a0w = A0W
   wmax = WMAX
+  clot_break_x = CLOT_BREAK_X
+  beta_limit = BETA_LIMIT
 }
 
 CohesionRHS {
@@ -126,6 +130,8 @@ CohesionRHS {
   a0 = A0
   a0w = A0W
   wmax = WMAX
+  clot_break_x = CLOT_BREAK_X
+  beta_limit = BETA_LIMIT
 }
 
 BoundaryMesh {


### PR DESCRIPTION
Because we are using pressure boundary conditions, the incoming flow is partly determined by what happens downstream of the cylinder. To try to eliminate this dependence, we can increase `beta` downstream of the cylinder so that the stress decays quickly.